### PR TITLE
  fix: replace hardcoded paths, simplify `idea()`, update deprecated macOS commands

### DIFF
--- a/.exports
+++ b/.exports
@@ -24,13 +24,7 @@ export GREP_COLOR='01;32';
 # Add `~/bin` to the `$PATH`
 export PATH="$HOME/bin:$PATH";
 		
-# Java 8
-#export JAVA_HOME_8=$(/usr/libexec/java_home -v1.8)
-#export JAVA_HOME_11=$(/usr/libexec/java_home -v11)
-export JAVA_HOME_17=/Library/Java/JavaVirtualMachines/jdk-17.0.2.jdk/Contents/Home
-
-# If multiple Java versions installed, quicly switch between them
-export JAVA_HOME=$JAVA_HOME_17
+export JAVA_HOME=$(/usr/libexec/java_home -v 17 2>/dev/null)
 
 # Python virtualenvwrapper (see https://virtualenvwrapper.readthedocs.io/en/latest/install.html)
 export PYENV_VIRTUALENVWRAPPER_PREFER_PYVENV="true"

--- a/.functions
+++ b/.functions
@@ -97,44 +97,9 @@ function afk() {
 	open -a ScreenSaverEngine;
 }
 
-# Open a specified folder in IntelliJ (CE or Ultimate)
+# Open a specified folder in IntelliJ IDEA
 function idea() {
-	PATH_TO_OPEN=''
-	IS_CE=0
-	OPTIND=1
-	while getopts ":ch" opt; do
-		case "${opt}" in
-			c)
-				IS_CE=1
-				;;
-			*) 
-				cat<<HELP_USAGE
-
-Usage: idea [OPTIONS] [PATH]
-
-Open the specified PATH in IntelliJ Idea. If no PATH is specified, use current path.
-
-Options:
-  -c Open the Community Edition.
-  -h Print usage
-HELP_USAGE
-				return 1
-		esac
-	done
-
-	if [ "$IS_CE" = 1 ]; then
-		PATH_TO_OPEN="${2:-''}"
-		IDEA_APP_PATH="/Applications/IntelliJ IDEA CE.app/"
-	else
-		PATH_TO_OPEN="${1:-''}"
-		IDEA_APP_PATH="/Applications/IntelliJ IDEA.app/"
-	fi
-
-	open -a "$IDEA_APP_PATH" $PATH_TO_OPEN
-
-	#open -a "/Applications/IntelliJ IDEA.app/"
-
-	return 0
+	open -a "/Applications/IntelliJ IDEA.app/" "${1:-}"
 }
 
 

--- a/.gitconfig
+++ b/.gitconfig
@@ -22,7 +22,7 @@
 	rebase = true
 [core]
 	autocrlf = input
-	excludesfile = /Users/rik/.gitignore_global
+	excludesfile = ~/.gitignore_global
 [alias]
        lg = log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --branches
 [filter "lfs"]

--- a/.macos
+++ b/.macos
@@ -4,7 +4,7 @@
 
 # Close any open System Preferences panes, to prevent them from overriding
 # settings we’re about to change
-osascript -e 'tell application "System Preferences" to quit'
+osascript -e 'tell application "System Settings" to quit'
 
 # Ask for the administrator password upfront
 sudo -v
@@ -143,9 +143,6 @@ EOD
 
 # Prevent Time Machine from prompting to use new hard drives as backup volume
 defaults write com.apple.TimeMachine DoNotOfferNewDisksForBackup -bool true
-
-# Disable local Time Machine backups
-hash tmutil &> /dev/null && sudo tmutil disablelocal
 
 
 ###############################################################################


### PR DESCRIPTION
- .gitconfig: replace hardcoded /Users/rik path with ~ for portability
- .exports: derive JAVA_HOME dynamically via java_home utility
- .functions: simplify idea() now that IntelliJ ships as a single app
- .macos: update System Preferences → System Settings (Ventura+), remove deprecated tmutil disablelocal