### PR TITLE
feat(install): add install.sh master installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,86 +1,62 @@
 # Rik's dotfiles
-Quickly configure your Mac.
 
-## CAUTION
-**Use these scripts at your risk**
+Quickly configure a fresh macOS development environment.
 
-These scripts will modify several configurations of your Mac, and will override existing files also. Before proceeding further, review the code and choose what configurations best suit you, removing what you don't need.
+## Caution
+
+**Use these scripts at your own risk.**
+
+These scripts will modify system configurations and overwrite existing files. Review the code and remove anything that doesn't suit your setup before running.
 
 ## Installation
 
-Clone the repository wherever you want and then choose what installation execute. You'll find details for each installation in the following sections.
+Clone the repository and run the installer:
 
 ```bash
-git clone https://github.com/zankyr/dotfiles.git && cd dotfiles
+git clone https://github.com/zankyr/dotfiles.git ~/.dotfiles
+cd ~/.dotfiles
+./install.sh
 ```
 
-### Homebrew formulae
+The installer will, in order:
 
-I like to install some common [Homebrew](https://brew.sh/) formulae (after installing Homebrew, of course):
+1. Install [Homebrew](https://brew.sh/) if not already present
+2. Install all packages and apps from `Brewfile`
+3. Symlink all dotfiles into `$HOME` via [GNU Stow](https://www.gnu.org/software/stow/)
+4. Apply macOS system defaults (`.macos`)
+5. Set zsh as the default shell
+
+To preview what would happen without making any changes:
 
 ```bash
-./brew/brew.sh
+./install.sh --dry-run
 ```
 
-Some of the functionality of following dotfiles depends on formulae installed by `brew.sh`. If you don’t plan to run `brew.sh`, you should look carefully through the script and manually install any particularly important ones. A good example is Bash/Git completion: the dotfiles use a special version from Homebrew.
+## Structure
 
-#### Extras
-If you want useful CLI tools or apps, look into `./brew/brew-extras.sh` and select what you like.
+Files are organised into [Stow](https://www.gnu.org/software/stow/) packages. Each directory maps directly to `$HOME`:
 
-### MacOs settings
-
-This script will configure several MacOS settings (like screensaver and password request after a stop). Just execute it. Be careful that after the execution, several applications will be closed to update their configurations.
-
-```bash
-./.macos
+```
+zsh/        → ~/.zshrc, ~/.zshenv, ~/.aliases, ~/.functions, ~/.hushlogin
+git/        → ~/.gitconfig, ~/.gitignore_global
+vim/        → ~/.vimrc, ~/.vim/
+starship/   → ~/.config/starship.toml
+mise/       → ~/.config/mise/config.toml
+macos/      → run directly by install.sh (not symlinked)
 ```
 
-### Dotfiles
+Running `stow <package>` from the repo root creates the symlinks. Running `stow -D <package>` removes them.
 
-To install the provided dotfiles in your system, execute the bootstrapper script with the `install` option.
+## Customisation
 
-```bash
-source bootstrap.sh --install
-```
-or
+- **Packages and apps** — edit `Brewfile` and run `brew bundle`
+- **Shell config** — edit files under `zsh/`
+- **Prompt** — edit `starship/.config/starship.toml`
+- **Runtime versions** (Java, etc.) — edit `mise/.config/mise/config.toml`
+- **macOS settings** — edit `macos/.macos`
 
-```bash
-source bootstrap.sh -i
-```
+Because Stow uses symlinks, editing a file in `$HOME` (e.g. `~/.aliases`) is the same as editing it in the repo — no sync step needed.
 
-This command will pull in the latest version and copy the files to your home folder.
-
-To synchronize your current configurations to the repository (e.g. you added new aliases or functions and you don't want to search what files you modified), execute the script using the `update` option:
-```bash
-source bootstrap.sh --update
-```
-or
-
-```bash
-source bootstrap.sh -u
-```
-This task will read the `from-file.txt` in order to keep track of which files to update, and then will sync them from your home directory to the repository folder.
-
-
-## Content
-* brew.sh -> install several [Homebrew](https://brew.sh/) formulae. Should be executed standalone.
-* .macos -> configure MacOs settings like TimeMachine, Dock and several others.
-* bootstrap.sh -> install all the dotfiles described below or update them (see section).
-* .aliases -> define useful aliases for the terminal.
-* .bash_profile -> compile all the dotfiles and define several other comodities (like bash completion and pyenv).
-* .bash_prompt -> configure the aspect (i.e. colors) for the terminal (and git also).
-* .exports -> define common exports variables.
-* .functions -> shortcuts that cannot be defined as simple aliases (like the extract command).
-* .gitconfig -> define colors for git statuses and other git configurations.
-* .gitignore_global -> global git ignore file
-* .hushlogin -> disable several messages in the terminale during the login phase.
-* .vimrc -> configurations for the vi text editor.
-* .vim -> folder that contains working direcotries for vim (like backup and swap) and the theme configuration.
-* init -> contain the Solarized Theme for the Terminal app.
-* bin -> contain the [setleds](https://github.com/damieng/setledsmac) script.
-* from-file -> list all the files and folders to syncronize (required for the bootstrap update command)
-
-## Thanks to…
+## Thanks to
 
 * [Mathias Bynens](https://mathiasbynens.be/) and his [dotfiles repository](https://github.com/mathiasbynens/dotfiles)
-* [Damien Guard](https://damieng.com/) for the [backlight script repository](https://github.com/damieng/setledsmac)

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DOTFILES="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DRY_RUN=false
+STOW_PACKAGES=(zsh git vim starship mise)
+
+# ------------------------------------------------------------------------------
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Set up a fresh macOS development environment from this dotfiles repo.
+
+Options:
+  --dry-run   Simulate changes without applying them (no installs, no writes)
+  -h, --help  Show this message
+EOF
+}
+
+log()  { echo "  $*"; }
+step() { echo; echo "==> $*"; }
+warn() { echo "  [warn] $*" >&2; }
+
+stow_flags() {
+  local flags=(--dir="$DOTFILES" --target="$HOME")
+  $DRY_RUN && flags+=(--simulate)
+  echo "${flags[@]}"
+}
+
+# ------------------------------------------------------------------------------
+
+install_homebrew() {
+  step "Homebrew"
+  if command -v brew &>/dev/null; then
+    log "already installed, skipping"
+    return
+  fi
+  if $DRY_RUN; then
+    log "[dry-run] would install Homebrew"
+    return
+  fi
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  # Apple Silicon: add brew to PATH for the rest of this script
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+}
+
+install_packages() {
+  step "Homebrew packages (Brewfile)"
+  if [[ ! -f "$DOTFILES/Brewfile" ]]; then
+    warn "Brewfile not found, skipping"
+    return
+  fi
+  if $DRY_RUN; then
+    log "[dry-run] would run: brew bundle --file=$DOTFILES/Brewfile"
+    return
+  fi
+  brew bundle --file="$DOTFILES/Brewfile"
+}
+
+stow_dotfiles() {
+  step "Stowing dotfiles"
+  if ! command -v stow &>/dev/null; then
+    warn "stow not found — install it first (brew install stow), skipping"
+    return
+  fi
+  for pkg in "${STOW_PACKAGES[@]}"; do
+    local pkg_dir="$DOTFILES/$pkg"
+    if [[ ! -d "$pkg_dir" ]]; then
+      warn "package '$pkg' not found, skipping"
+      continue
+    fi
+    log "stow $pkg"
+    # shellcheck disable=SC2046
+    stow $(stow_flags) "$pkg"
+  done
+}
+
+apply_macos_defaults() {
+  step "macOS defaults"
+  local macos_script="$DOTFILES/macos/.macos"
+  if [[ ! -f "$macos_script" ]]; then
+    warn ".macos script not found, skipping"
+    return
+  fi
+  if $DRY_RUN; then
+    log "[dry-run] would run: $macos_script"
+    return
+  fi
+  bash "$macos_script"
+}
+
+set_default_shell() {
+  step "Default shell"
+  local zsh_path
+  zsh_path="$(command -v zsh)"
+  if [[ "$SHELL" == "$zsh_path" ]]; then
+    log "zsh is already the default shell, skipping"
+    return
+  fi
+  if $DRY_RUN; then
+    log "[dry-run] would run: chsh -s $zsh_path"
+    return
+  fi
+  # zsh must be in /etc/shells for chsh to accept it
+  if ! grep -qxF "$zsh_path" /etc/shells; then
+    echo "$zsh_path" | sudo tee -a /etc/shells >/dev/null
+  fi
+  chsh -s "$zsh_path"
+  log "default shell set to $zsh_path"
+}
+
+# ------------------------------------------------------------------------------
+
+main() {
+  for arg in "$@"; do
+    case "$arg" in
+      --dry-run)   DRY_RUN=true ;;
+      -h|--help)   usage; exit 0 ;;
+      *)           echo "Unknown option: $arg"; usage; exit 1 ;;
+    esac
+  done
+
+  $DRY_RUN && echo "(dry-run mode — no changes will be made)"
+
+  install_homebrew
+  install_packages
+  stow_dotfiles
+  apply_macos_defaults
+  set_default_shell
+
+  echo
+  echo "Done."
+  $DRY_RUN && echo "(dry-run: nothing was actually changed)"
+}
+
+main "$@"

--- a/install.sh
+++ b/install.sh
@@ -19,9 +19,18 @@ Options:
 EOF
 }
 
-log()  { echo "  $*"; }
-step() { echo; echo "==> $*"; }
-warn() { echo "  [warn] $*" >&2; }
+BOLD='\033[1m'
+RESET='\033[0m'
+BLUE='\033[0;34m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+CYAN='\033[0;36m'
+
+log()  { echo -e "  ${GREEN}✔${RESET}  $*"; }
+step() { echo; echo -e "${BOLD}${BLUE}==> $*${RESET}"; }
+warn() { echo -e "  ${YELLOW}⚠${RESET}  $*" >&2; }
+error(){ echo -e "  ${RED}✖${RESET}  $*" >&2; }
 
 stow_flags() {
   local flags=(--dir="$DOTFILES" --target="$HOME")
@@ -118,11 +127,11 @@ main() {
     case "$arg" in
       --dry-run)   DRY_RUN=true ;;
       -h|--help)   usage; exit 0 ;;
-      *)           echo "Unknown option: $arg"; usage; exit 1 ;;
+      *)           error "Unknown option: $arg"; usage; exit 1 ;;
     esac
   done
 
-  $DRY_RUN && echo "(dry-run mode — no changes will be made)"
+  $DRY_RUN && echo -e "${CYAN}(dry-run mode — no changes will be made)${RESET}"
 
   install_homebrew
   install_packages
@@ -131,8 +140,8 @@ main() {
   set_default_shell
 
   echo
-  echo "Done."
-  $DRY_RUN && echo "(dry-run: nothing was actually changed)"
+  echo -e "${BOLD}${GREEN}Done.${RESET}"
+  $DRY_RUN && echo -e "${CYAN}(dry-run: nothing was actually changed)${RESET}"
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

Replaces `bootstrap.sh` with a new `install.sh` that bootstraps a fresh Mac end-to-end.

## What it does (in order)

1. **Homebrew**: detects and installs if missing (Apple Silicon path aware)
2. **`brew bundle`**: installs all packages from `Brewfile`
3. **Stow**: symlinks each package (`zsh`, `git`, `vim`, `starship`, `mise`) into `$HOME`
4. **`.macos`**: applies macOS system defaults
5. **Default shell**: sets zsh via `chsh`, adds it to `/etc/shells` if needed

## Features

- `--dry-run` flag: simulates every step without making changes
- Idempotent: safe to re-run (skips already-done steps)
- Graceful degradation: warns and skips missing `Brewfile` or `stow`

🤖 Generated with [Claude Code](https://claude.com/claude-code)