### PR TITLE
feat(starship): add starship prompt config

### DIFF
--- a/starship/.config/starship.toml
+++ b/starship/.config/starship.toml
@@ -1,3 +1,6 @@
+# Inserts a blank line between shell prompts
+add_newline = true
+
 [directory]
 truncation_length = 3
 truncate_to_repo = true
@@ -23,5 +26,6 @@ min_time = 2000
 format = "took [$duration]($style) "
 
 [character]
-success_symbol = "[❯](bold green)"
+#success_symbol = "[❯](bold green)"
+success_symbol = '[➜](bold green)'
 error_symbol = "[❯](bold red)"

--- a/starship/.config/starship.toml
+++ b/starship/.config/starship.toml
@@ -1,0 +1,27 @@
+[directory]
+truncation_length = 3
+truncate_to_repo = true
+
+[git_branch]
+symbol = " "
+
+[git_status]
+conflicted = "✘"
+ahead = "⇡${count}"
+behind = "⇣${count}"
+diverged = "⇕⇡${ahead_count}⇣${behind_count}"
+untracked = "?"
+modified = "!"
+staged = "+"
+deleted = "✘"
+
+[java]
+detect_extensions = ["java", "class", "gradle", "jar", "pom"]
+
+[cmd_duration]
+min_time = 2000
+format = "took [$duration]($style) "
+
+[character]
+success_symbol = "[❯](bold green)"
+error_symbol = "[❯](bold red)"


### PR DESCRIPTION
## Summary
- Creates `starship/.config/starship.toml` as a GNU Stow package
- Configures directory (truncated, repo-aware), git branch/status, Java version (auto-detected in Java projects), and command duration for slow commands (>2s)
- Replaces implicit Starship defaults with an explicit, version-stable config

🤖 Generated with [Claude Code](https://claude.com/claude-code)