### PR TITLE
feat(mise): add mise global config as stow package

### DIFF
--- a/mise/.config/mise/config.toml
+++ b/mise/.config/mise/config.toml
@@ -1,0 +1,4 @@
+# Runtime versions are managed per-project via .mise.toml in each project root.
+# Add global tools here only for runtimes needed everywhere, e.g.:
+# [tools]
+# node = "lts"


### PR DESCRIPTION
## Summary
- Creates `mise/.config/mise/config.toml` as a GNU Stow package
- No global Java pin — runtime versions are managed per-project via `.mise.toml` in each project root
- Stow symlinks `~/.config/mise/` → dotfiles repo (directory-level symlink)

🤖 Generated with [Claude Code](https://claude.com/claude-code)