### PR TITLE
feat(git): add work identity via includeIf for ~/dev/klab

### DIFF
--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -35,3 +35,5 @@
 	process = git-lfs filter-process
 [init]
 	defaultBranch = main
+[includeIf "gitdir:~/dev/klab/"]
+	path = ~/.gitconfig-work

--- a/git/.gitconfig-work
+++ b/git/.gitconfig-work
@@ -1,0 +1,3 @@
+[user]
+	name = Your Name
+	email = your.name@company.com


### PR DESCRIPTION
## Summary
- Adds `[includeIf "gitdir:~/dev/klab/"]` to `.gitconfig` — any repo under `~/dev/klab/` automatically uses the work identity
- Adds `git/.gitconfig-work` template (stowed to `~/.gitconfig-work`) with placeholder name/email to fill in

🤖 Generated with [Claude Code](https://claude.com/claude-code)